### PR TITLE
Ttgo xi

### DIFF
--- a/lgt8f/boards.txt
+++ b/lgt8f/boards.txt
@@ -49,6 +49,11 @@ menu.variant=Variant
 328.menu.variant.modelP.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
 328.menu.variant.modelP.build.variant=lgt8fx8p
 
+328.menu.variant.modelP=wemos-TTGO-XI
+328.menu.variant.modelP.bootloader.path=lgt8fx8p
+328.menu.variant.modelP.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
+328.menu.variant.modelP.build.variant=lgt8fx8p-wemos-TTGO-XI
+
 328.menu.variant.modelD=328D (e.g. WAVGAT AVG328D)
 328.menu.variant.modelD.bootloader.path=lgt8fx8e
 328.menu.variant.modelD.bootloader.file=lgt8fx8e/optiboot_lgt8f328d.hex

--- a/lgt8f/variants/lgt8fx8p-wemos-TTGO-XI/pins_arduino.h
+++ b/lgt8f/variants/lgt8fx8p-wemos-TTGO-XI/pins_arduino.h
@@ -1,0 +1,43 @@
+/*
+  pins_arduino.h - Pin definition functions for Arduino
+  Part of Arduino - http://www.arduino.cc/
+
+  Copyright (c) 2007 David A. Mellis
+
+  This library is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 2.1 of the License, or (at your option) any later version.
+
+  This library is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+
+  You should have received a copy of the GNU Lesser General
+  Public License along with this library; if not, write to the
+  Free Software Foundation, Inc., 59 Temple Place, Suite 330,
+  Boston, MA  02111-1307  USA
+
+  $Id: wiring.h 249 2007-02-03 16:52:51Z mellis $
+*/
+
+#ifndef __LGT8FX8P__
+#define	__LGT8FX8P__
+
+#ifndef __LGT8F__
+#define	__LGT8F__
+#endif
+
+#include "lgtx8p.h"
+
+static const uint8_t DAC0 = 4;
+
+#include "../standard/pins_arduino.h"
+#undef NUM_ANALOG_INPUTS
+#define NUM_ANALOG_INPUTS           8
+
+#undef LED_BUILTIN
+#define LED_BUILTIN 12
+
+#endif


### PR DESCRIPTION
Added support for the wemos TTGI-XI boards based off of the lgt8fx8p variant.  Added board specific variant directory and files.  Edited boards.txt to support variant.