### PR TITLE
adds support for external 32MHz crystal

### DIFF
--- a/lgt8f/boards.txt
+++ b/lgt8f/boards.txt
@@ -2,6 +2,7 @@
 # Based on https://github.com/LGTMCU/Larduino_HSP
 
 # Menu options
+menu.clock_source=Clock Source
 menu.clock=Clock
 menu.variant=Variant
 
@@ -24,19 +25,25 @@ menu.variant=Variant
 328.build.mcu=atmega328p
 328.build.board=AVR_LARDU_328E
 
+# Clock source
+328.menu.clock_source.internal=Internal
+328.menu.clock_source.internal.build.clock_source=1
+328.menu.clock_source.external=External (assumes 32MHz crystal)
+328.menu.clock_source.external.build.clock_source=2
+
 # Clock frequencies
-328.menu.clock.32MHz_internal=32 MHz internal
-328.menu.clock.32MHz_internal.build.f_cpu=32000000L
-328.menu.clock.16MHz_internal=16 MHz internal
-328.menu.clock.16MHz_internal.build.f_cpu=16000000L
-328.menu.clock.8MHz_internal=8 MHz internal
-328.menu.clock.8MHz_internal.build.f_cpu=8000000L
-328.menu.clock.4MHz_internal=4 MHz internal
-328.menu.clock.4MHz_internal.build.f_cpu=4000000L
-328.menu.clock.2MHz_internal=2 MHz internal
-328.menu.clock.2MHz_internal.build.f_cpu=2000000L
-328.menu.clock.1MHz_internal=1 MHz internal
-328.menu.clock.1MHz_internal.build.f_cpu=1000000L
+328.menu.clock.32MHz=32 MHz
+328.menu.clock.32MHz.build.f_cpu=32000000L
+328.menu.clock.16MHz=16 MHz
+328.menu.clock.16MHz.build.f_cpu=16000000L
+328.menu.clock.8MHz=8 MHz
+328.menu.clock.8MHz.build.f_cpu=8000000L
+328.menu.clock.4MHz=4 MHz
+328.menu.clock.4MHz.build.f_cpu=4000000L
+328.menu.clock.2MHz=2 MHz
+328.menu.clock.2MHz.build.f_cpu=2000000L
+328.menu.clock.1MHz=1 MHz
+328.menu.clock.1MHz.build.f_cpu=1000000L
 
 # Variants
 328.menu.variant.modelP48=328P-LQFP48 MiniEVB
@@ -83,19 +90,25 @@ menu.variant=Variant
 88.build.core=lgt8f
 88.build.board=AVR_LARDU_88DS20
 
+# Clock source
+88.menu.clock_source.internal=Internal
+88.menu.clock_source.internal.build.clock_source=1
+88.menu.clock_source.external=External (assumes 32MHz crystal)
+88.menu.clock_source.external.build.clock_source=2
+
 # Clock frequencies
-88.menu.clock.32MHz_internal=32 MHz internal
-88.menu.clock.32MHz_internal.build.f_cpu=32000000L
-88.menu.clock.16MHz_internal=16 MHz internal
-88.menu.clock.16MHz_internal.build.f_cpu=16000000L
-88.menu.clock.8MHz_internal=8 MHz internal
-88.menu.clock.8MHz_internal.build.f_cpu=8000000L
-88.menu.clock.4MHz_internal=4 MHz internal
-88.menu.clock.4MHz_internal.build.f_cpu=4000000L
-88.menu.clock.2MHz_internal=2 MHz internal
-88.menu.clock.2MHz_internal.build.f_cpu=2000000L
-88.menu.clock.1MHz_internal=1 MHz internal
-88.menu.clock.1MHz_internal.build.f_cpu=1000000L
+88.menu.clock.32MHz=32 MHz
+88.menu.clock.32MHz.build.f_cpu=32000000L
+88.menu.clock.16MHz=16 MHz
+88.menu.clock.16MHz.build.f_cpu=16000000L
+88.menu.clock.8MHz=8 MHz
+88.menu.clock.8MHz.build.f_cpu=8000000L
+88.menu.clock.4MHz=4 MHz
+88.menu.clock.4MHz.build.f_cpu=4000000L
+88.menu.clock.2MHz=2 MHz
+88.menu.clock.2MHz.build.f_cpu=2000000L
+88.menu.clock.1MHz=1 MHz
+88.menu.clock.1MHz.build.f_cpu=1000000L
 
 # Variants
 88.menu.variant.modelD=LGT8F88D-SSOP20

--- a/lgt8f/cores/lgt8f/main.cpp
+++ b/lgt8f/cores/lgt8f/main.cpp
@@ -106,11 +106,47 @@ void lgt8fx8x_init()
 #endif
 }
 
+// START CHANGE BY DBUEZAS & SEISFELD
+void lgt8fx8x_clk_src()
+{
+// select clock source
+#if defined(CLOCK_SOURCE)
+    #if CLOCK_SOURCE == 1
+        // internal clock is default, do nothing
+        // sysClock(INT_OSC);
+    #elif CLOCK_SOURCE == 2
+        sysClock(EXT_OSC);
+    #endif
+#endif
+
+// select clock prescaler
+#if defined(F_CPU)
+    CLKPR = 0x80;
+    #if F_CPU == 32000000L
+        CLKPR = 0x00;
+    #elif F_CPU == 16000000L
+        CLKPR = 0x01;
+    #elif F_CPU == 8000000L
+        CLKPR = 0x02;
+    #elif F_CPU == 4000000L
+        CLKPR = 0x03;
+    #elif F_CPU == 2000000L
+        CLKPR = 0x04;
+    #elif F_CPU == 1000000L
+        CLKPR = 0x05;
+    #endif
+#endif
+}
+// END CHANGE BY DBUEZAS & SEISFELD
+
 int main(void)
 {
 
 #if defined(__LGT8F__)
 	lgt8fx8x_init();
+	#if defined(CLOCK_SOURCE)
+	    lgt8fx8x_clk_src();
+	#endif
 #endif	
 
 	init();
@@ -120,23 +156,7 @@ int main(void)
 #if defined(USBCON)
 	USBDevice.attach();
 #endif
-/* START CHANGE BY DBUEZAS */
-  // set clock prescaler
-	CLKPR = 0x80;
-#if F_CPU == 32000000L
-  CLKPR = 0x00;
-#elif F_CPU == 16000000L
-  CLKPR = 0x01;
-#elif F_CPU == 8000000L
-  CLKPR = 0x02;
-#elif F_CPU == 4000000L
-  CLKPR = 0x03;
-#elif F_CPU == 2000000L
-  CLKPR = 0x04;
-#elif F_CPU == 1000000L
-  CLKPR = 0x05;
-#endif
-/* END CHANGE BY DBUEZAS */
+
 	setup();
     
 	for (;;) {

--- a/lgt8f/platform.txt
+++ b/lgt8f/platform.txt
@@ -51,13 +51,13 @@ compiler.elf2hex.extra_flags=
 # --------------------
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mmcu={build.mcu} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mmcu={build.mcu} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
-recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 # archive_file_path is needed for backwards compatibility with IDE 1.6.5 or older, IDE 1.6.6 or newer overrides this value
@@ -83,10 +83,10 @@ recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 
 ## Preprocessor
 preproc.includes.flags=-w -x c++ -M -MG -MP
-recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
+recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
 
 preproc.macros.flags=-w -x c++ -E -CC
-recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
+recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
 
 # AVR Uploader/Programmers tools
 # ------------------------------


### PR DESCRIPTION
Hi David,

this adds support for an external 32MHz crystal connected to LGT8F328P Port B Pin 6 & 7 (see databook for details). You can comfortably switch between the internal and external OSC using the tools menu:

<img width="704" alt="image" src="https://user-images.githubusercontent.com/9606362/69888913-ae0faa00-12ee-11ea-8cb1-f0ad0d2e62f6.png">

And then pick the speed you want to run at (I tested 16MHz as well as 32MHz, but I kept the other options as well). This directly sets the prescaler to the correct value:

<img width="539" alt="image" src="https://user-images.githubusercontent.com/9606362/69888921-b8ca3f00-12ee-11ea-9c5b-2a286446a0ba.png">

cheers
Stephan