### PR TITLE
revise delay timing

### DIFF
--- a/lgt8f/libraries/SoftwareSerial/SoftwareSerial.cpp
+++ b/lgt8f/libraries/SoftwareSerial/SoftwareSerial.cpp
@@ -56,7 +56,7 @@ http://arduiniana.org.
     Thus, at a CPU speed of 1 MHz, delays of up to about 262.1
     milliseconds can be achieved.
  */
-__attribute__((always_inline)) static inline void SoftwareSerial::_delay_loop_2(uint16_t __count)
+void SoftwareSerial::_delay_loop_2(uint16_t __count)
 {
 	__asm__ volatile (
 		"1: sbiw %0,1" "\n\t"
@@ -104,7 +104,7 @@ inline void DebugPulse(uint8_t, uint8_t) {}
 //
 
 /* static */ 
-__attribute__((always_inline)) static inline void SoftwareSerial::tunedDelay(uint16_t delay) { 
+void SoftwareSerial::tunedDelay(uint16_t delay) { 
   _delay_loop_2(delay);
 }
 

--- a/lgt8f/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/lgt8f/libraries/SoftwareSerial/SoftwareSerial.h
@@ -85,7 +85,7 @@ private:
   static uint16_t subtract_cap(uint16_t num, uint16_t sub);
 
   // private static method for timing
-  static void _delay_loop_2(uint16_t __count);
+  static inline void _delay_loop_2(uint16_t __count);
   static inline void tunedDelay(uint16_t delay);
 
 public:

--- a/lgt8f/libraries/SoftwareSerial/SoftwareSerial.h
+++ b/lgt8f/libraries/SoftwareSerial/SoftwareSerial.h
@@ -84,9 +84,9 @@ private:
   // Return num - sub, or 1 if the result would be < 1
   static uint16_t subtract_cap(uint16_t num, uint16_t sub);
 
-  // private static method for timing
-  static inline void _delay_loop_2(uint16_t __count);
-  static inline void tunedDelay(uint16_t delay);
+  // private methods for timing
+  inline void _delay_loop_2(uint16_t __count) __attribute__((__always_inline__));
+  inline void tunedDelay(uint16_t delay) __attribute__((__always_inline__));
 
 public:
   // public methods


### PR DESCRIPTION
some LGT8x instructions are faster than original AVR's.
especially PUSH/POP/RET/LD/LDD/ST/STD/RJMP take 1 clock, it needs
re-calculate delay value.

_delay_loop_2() and tunedDelay() added always_inline attribute.
This is disadvantage for memory usage but no need to worry about
calculating CALL/RET clock cycle.

under my brief testing, the result of previous code was

230400bps Rx failed @ 8MHz, TRx failed @ 4MHz
115200bps                    Rx failed @ 4MHz

but now

230400bps TRx failed @ 8MHz,  Rx failed @ 4MHz
115200bps                    TRx failed @ 4MHz

anyway 115200bps and higher transfer rate is not recommended for
8MHz and under CPU clock.