### PR TITLE
add 2buffer transfer version

### DIFF
--- a/lgt8f/libraries/SPI/src/SPI.h
+++ b/lgt8f/libraries/SPI/src/SPI.h
@@ -310,6 +310,30 @@ public:
 #endif
   }
 
+#if defined(__LGT8F__)
+#define SPI_HAS_TRANSFER_BUF
+  inline static void transfer(void * buf, void * retbuf, size_t count) {
+    if (count == 0) return;
+  
+     uint8_t *p = (uint8_t *)buf;
+     uint8_t *pret = (uint8_t *)retbuf;
+     size_t writecount = count;
+  
+     while(count>0||writecount>0) {
+       uint8_t spfr = SPFR;
+       if (writecount>0 && (!(spfr & _BV(WRFULL)))) {
+         SPDR = p ? *p++ : 0;
+         writecount--;
+         }
+       if (count>0 && (!(spfr & _BV(RDEMPT)))) {
+         uint8_t in = SPDR;
+         if (pret) *pret++ = in;
+         count--;
+         }
+     }
+}
+#endif
+
   // After performing a group of transfers and releasing the chip select
   // signal, this function allows others to access the SPI bus
   inline static void endTransaction(void) {

--- a/lgt8f/libraries/SPI/src/SPI.h
+++ b/lgt8f/libraries/SPI/src/SPI.h
@@ -356,6 +356,8 @@ public:
           }
         }
       }
+    asm ( "nop;\n" );
+    asm ( "nop;\n" );
     }
 #endif
 

--- a/lgt8f/libraries/SPI/src/SPI.h
+++ b/lgt8f/libraries/SPI/src/SPI.h
@@ -312,53 +312,7 @@ public:
 
 #if defined(__LGT8F__)
 #define SPI_HAS_TRANSFER_BUF
-  inline static void transfer(void * buf, void * retbuf, size_t count) {
-    if (count == 0) return;
-
-    uint8_t *p = (uint8_t *)buf;
-    uint8_t *pret = (uint8_t *)retbuf;
-    size_t writecount = count;
-
-    if (buf && !retbuf) {
-      // optimized version: we only need to SEND
-      while(writecount-->0) {
-        while(SPFR & _BV(WRFULL));
-        SPDR = *p++;
-        if (!(SPFR & _BV(RDEMPT))) { uint8_t in = SPDR; count--; }
-        }
-      while (count-->0) {
-        while (SPFR & _BV(RDEMPT));
-        uint8_t in = SPDR;
-        }
-      }
-    else if (!buf && retbuf) {
-      // optimized version: we only need to RECEIVE
-      while(writecount-->0) {
-        while(SPFR & _BV(WRFULL));
-        SPDR = 0;
-        if (!(SPFR & _BV(RDEMPT))) { *pret++=SPDR; count--; }
-        }
-      while (count-->0) {
-        while (SPFR & _BV(RDEMPT));
-        *pret++=SPDR;
-        }
-      }
-    else {
-      while(count>0||writecount>0) {
-        if (writecount>0 && (!(SPFR & _BV(WRFULL)))) {
-          SPDR = p ? *p++ : 0;
-          writecount--;
-          }
-        if (count>0 && (!(SPFR & _BV(RDEMPT)))) {
-          uint8_t in = SPDR;
-          if (pret) *pret++ = in;
-          count--;
-          }
-        }
-      }
-    asm ( "nop;\n" );
-    asm ( "nop;\n" );
-    }
+  const static void SPIClass::transfer(void * buf, void * retbuf, size_t count);
 #endif
 
   // After performing a group of transfers and releasing the chip select

--- a/lgt8f/libraries/SPI/src/SPI.h
+++ b/lgt8f/libraries/SPI/src/SPI.h
@@ -314,23 +314,49 @@ public:
 #define SPI_HAS_TRANSFER_BUF
   inline static void transfer(void * buf, void * retbuf, size_t count) {
     if (count == 0) return;
-  
-     uint8_t *p = (uint8_t *)buf;
-     uint8_t *pret = (uint8_t *)retbuf;
-     size_t writecount = count;
-  
-     while(count>0||writecount>0) {
-       if (writecount>0 && (!(SPFR & _BV(WRFULL)))) {
-         SPDR = p ? *p++ : 0;
-         writecount--;
-         }
-       if (count>0 && (!(SPFR & _BV(RDEMPT)))) {
-         uint8_t in = SPDR;
-         if (pret) *pret++ = in;
-         count--;
-         }
-     }
-}
+
+    uint8_t *p = (uint8_t *)buf;
+    uint8_t *pret = (uint8_t *)retbuf;
+    size_t writecount = count;
+
+    if (buf && !retbuf) {
+      // optimized version: we only need to SEND
+      while(writecount-->0) {
+        while(SPFR & _BV(WRFULL));
+        SPDR = *p++;
+        if (!(SPFR & _BV(RDEMPT))) { uint8_t in = SPDR; count--; }
+        }
+      while (count-->0) {
+        while (SPFR & _BV(RDEMPT));
+        uint8_t in = SPDR;
+        }
+      }
+    else if (!buf && retbuf) {
+      // optimized version: we only need to RECEIVE
+      while(writecount-->0) {
+        while(SPFR & _BV(WRFULL));
+        SPDR = 0;
+        if (!(SPFR & _BV(RDEMPT))) { *pret++=SPDR; count--; }
+        }
+      while (count-->0) {
+        while (SPFR & _BV(RDEMPT));
+        *pret++=SPDR;
+        }
+      }
+    else {
+      while(count>0||writecount>0) {
+        if (writecount>0 && (!(SPFR & _BV(WRFULL)))) {
+          SPDR = p ? *p++ : 0;
+          writecount--;
+          }
+        if (count>0 && (!(SPFR & _BV(RDEMPT)))) {
+          uint8_t in = SPDR;
+          if (pret) *pret++ = in;
+          count--;
+          }
+        }
+      }
+    }
 #endif
 
   // After performing a group of transfers and releasing the chip select

--- a/lgt8f/libraries/SPI/src/SPI.h
+++ b/lgt8f/libraries/SPI/src/SPI.h
@@ -320,12 +320,11 @@ public:
      size_t writecount = count;
   
      while(count>0||writecount>0) {
-       uint8_t spfr = SPFR;
-       if (writecount>0 && (!(spfr & _BV(WRFULL)))) {
+       if (writecount>0 && (!(SPFR & _BV(WRFULL)))) {
          SPDR = p ? *p++ : 0;
          writecount--;
          }
-       if (count>0 && (!(spfr & _BV(RDEMPT)))) {
+       if (count>0 && (!(SPFR & _BV(RDEMPT)))) {
          uint8_t in = SPDR;
          if (pret) *pret++ = in;
          count--;


### PR DESCRIPTION
PR as of trying to get Ethernet.h faster.
See notes to Ethernet.h at https://github.com/dbuezas/lgt8fx/wiki/Libraries-support
The library uses a (then existant) function, if SPI_HAS_TRANSFER_BUF is defined. If not, it does call transfer() for each byte.

As of Teeny source:
```
// SPI_HAS_TRANSFER_BUF - is defined to signify that this library supports
// a version of transfer which allows you to pass in both TX and RX buffer
// pointers, either of which could be NULL
```
Added this define, and added the function to do so. 
The function is not fast enough to keep SCK running free at 16MHz SPI, but still faster than the one used before.
Reading+Writing with 2MByte/sec at 32MHz MCU doesn't seem possible ^^

At 8MHz SPI it makes SOME difference.

