### PR TITLE
fixed missing #endif

### DIFF
--- a/lgt8f/cores/lgt8f/wiring.c
+++ b/lgt8f/cores/lgt8f/wiring.c
@@ -198,7 +198,7 @@ void delayMicroseconds(unsigned int us)
 	us -= 4; // = 2 cycles
 #endif
 
-#if F_CPU >= 24000000L
+#elif F_CPU >= 24000000L
 	// for the 24 MHz external clock if somebody is working with USB
 
 	// is there any reason for zero delay fix?


### PR DESCRIPTION
@LaZsolt can you check if this was the intended code?

The way it is now in master doesn't compile: `the #endif for this directive is missingC/C++(37) on line 146`

I don't know if `us *= 6;` is supposed to happen for all clocks >=24MHz  or only between 24Hz and 25MHz.