### PR TITLE
add oscillator clock definition

### DIFF
--- a/lgt8f/boards.txt
+++ b/lgt8f/boards.txt
@@ -36,8 +36,10 @@ menu.arduino_isp=Arduino as ISP
 # Clock source
 328.menu.clock_source.internal=Internal
 328.menu.clock_source.internal.build.clock_source=1
+328.menu.clock_source.internal.build.f_osc=32000000L
 328.menu.clock_source.external=External (assumes 32MHz crystal)
 328.menu.clock_source.external.build.clock_source=2
+328.menu.clock_source.external.build.f_osc=32000000L
 
 # Clock frequencies
 328.menu.clock.32MHz=32 MHz
@@ -105,8 +107,10 @@ menu.arduino_isp=Arduino as ISP
 # Clock source
 88.menu.clock_source.internal=Internal
 88.menu.clock_source.internal.build.clock_source=1
+88.menu.clock_source.internal.build.f_osc=32000000L
 88.menu.clock_source.external=External (assumes 32MHz crystal)
 88.menu.clock_source.external.build.clock_source=2
+88.menu.clock_source.external.build.f_osc=32000000L
 
 # Clock frequencies
 88.menu.clock.32MHz=32 MHz
@@ -153,6 +157,7 @@ lardu_328e.build.board=AVR_LARDU_328E
 # Clock source
 lardu_328e.menu.clock_source.internal=Internal
 lardu_328e.menu.clock_source.internal.build.clock_source=1
+lardu_328e.menu.clock_source.internal.build.f_osc=32000000L
 
 # Clock frequencies
 lardu_328e.menu.clock.16MHz=16 MHz (default internal osc)

--- a/lgt8f/boards.txt
+++ b/lgt8f/boards.txt
@@ -43,17 +43,17 @@ menu.arduino_isp=Arduino as ISP
 
 # Clock frequencies
 328.menu.clock.32MHz=32 MHz
-328.menu.clock.32MHz.build.f_cpu=32000000L
+328.menu.clock.32MHz.build.f_div=1
 328.menu.clock.16MHz=16 MHz
-328.menu.clock.16MHz.build.f_cpu=16000000L
+328.menu.clock.16MHz.build.f_div=2
 328.menu.clock.8MHz=8 MHz
-328.menu.clock.8MHz.build.f_cpu=8000000L
+328.menu.clock.8MHz.build.f_div=4
 328.menu.clock.4MHz=4 MHz
-328.menu.clock.4MHz.build.f_cpu=4000000L
+328.menu.clock.4MHz.build.f_div=8
 328.menu.clock.2MHz=2 MHz
-328.menu.clock.2MHz.build.f_cpu=2000000L
+328.menu.clock.2MHz.build.f_div=16
 328.menu.clock.1MHz=1 MHz
-328.menu.clock.1MHz.build.f_cpu=1000000L
+328.menu.clock.1MHz.build.f_div=32
 
 # Variants
 328.menu.variant.modelP48=328P-LQFP48 MiniEVB
@@ -114,17 +114,17 @@ menu.arduino_isp=Arduino as ISP
 
 # Clock frequencies
 88.menu.clock.32MHz=32 MHz
-88.menu.clock.32MHz.build.f_cpu=32000000L
+88.menu.clock.32MHz.build.f_div=1
 88.menu.clock.16MHz=16 MHz
-88.menu.clock.16MHz.build.f_cpu=16000000L
+88.menu.clock.16MHz.build.f_div=2
 88.menu.clock.8MHz=8 MHz
-88.menu.clock.8MHz.build.f_cpu=8000000L
+88.menu.clock.8MHz.build.f_div=4
 88.menu.clock.4MHz=4 MHz
-88.menu.clock.4MHz.build.f_cpu=4000000L
+88.menu.clock.4MHz.build.f_div=8
 88.menu.clock.2MHz=2 MHz
-88.menu.clock.2MHz.build.f_cpu=2000000L
+88.menu.clock.2MHz.build.f_div=16
 88.menu.clock.1MHz=1 MHz
-88.menu.clock.1MHz.build.f_cpu=1000000L
+88.menu.clock.1MHz.build.f_div=32
 
 # Variants
 88.menu.variant.modelD=LGT8F88D-SSOP20
@@ -161,15 +161,15 @@ lardu_328e.menu.clock_source.internal.build.f_osc=32000000L
 
 # Clock frequencies
 lardu_328e.menu.clock.16MHz=16 MHz (default internal osc)
-lardu_328e.menu.clock.16MHz.build.f_cpu=16000000L
+lardu_328e.menu.clock.16MHz.build.f_div=2
 lardu_328e.menu.clock.8MHz=8 MHz
-lardu_328e.menu.clock.8MHz.build.f_cpu=8000000L
+lardu_328e.menu.clock.8MHz.build.f_div=4
 lardu_328e.menu.clock.4MHz=4 MHz
-lardu_328e.menu.clock.4MHz.build.f_cpu=4000000L
+lardu_328e.menu.clock.4MHz.build.f_div=8
 lardu_328e.menu.clock.2MHz=2 MHz
-lardu_328e.menu.clock.2MHz.build.f_cpu=2000000L
+lardu_328e.menu.clock.2MHz.build.f_div=16
 lardu_328e.menu.clock.1MHz=1 MHz
-lardu_328e.menu.clock.1MHz.build.f_cpu=1000000L
+lardu_328e.menu.clock.1MHz.build.f_div=32
 
 # Arduino as ISP
 

--- a/lgt8f/boards.txt
+++ b/lgt8f/boards.txt
@@ -157,21 +157,6 @@ menu.upload_speed=Upload speed
 328_16.menu.clock.1M_i.build.f_osc=32000000L
 328_16.menu.clock.1M_i.build.f_div=32
 
-328_16.menu.clock.500k_i=Internal 500 kHz
-328_16.menu.clock.500k_i.build.clock_source=1
-328_16.menu.clock.500k_i.build.f_osc=32000000L
-328_16.menu.clock.500k_i.build.f_div=64
-
-328_16.menu.clock.250k_i=Internal 250 kHz
-328_16.menu.clock.250k_i.build.clock_source=1
-328_16.menu.clock.250k_i.build.f_osc=32000000L
-328_16.menu.clock.250k_i.build.f_div=128
-
-328_16.menu.clock.125k_i=Internal 125 kHz
-328_16.menu.clock.125k_i.build.clock_source=1
-328_16.menu.clock.125k_i.build.f_osc=32000000L
-328_16.menu.clock.125k_i.build.f_div=256
-
 328_16.menu.clock.16M_e=External 16 MHz
 328_16.menu.clock.16M_e.build.clock_source=2
 328_16.menu.clock.16M_e.build.f_osc=16000000L
@@ -196,26 +181,6 @@ menu.upload_speed=Upload speed
 328_16.menu.clock.1M_e.build.clock_source=2
 328_16.menu.clock.1M_e.build.f_osc=16000000L
 328_16.menu.clock.1M_e.build.f_div=16
-
-328_16.menu.clock.500k_e=External 500 kHz
-328_16.menu.clock.500k_e.build.clock_source=2
-328_16.menu.clock.500k_e.build.f_osc=16000000L
-328_16.menu.clock.500k_e.build.f_div=32
-
-328_16.menu.clock.250k_e=External 250 kHz
-328_16.menu.clock.250k_e.build.clock_source=2
-328_16.menu.clock.250k_e.build.f_osc=16000000L
-328_16.menu.clock.250k_e.build.f_div=64
-
-328_16.menu.clock.125k_e=External 125 kHz
-328_16.menu.clock.125k_e.build.clock_source=2
-328_16.menu.clock.125k_e.build.f_osc=16000000L
-328_16.menu.clock.125k_e.build.f_div=128
-
-328_16.menu.clock.62k_e=External 62.5 kHz
-328_16.menu.clock.62k_e.build.clock_source=2
-328_16.menu.clock.62k_e.build.f_osc=16000000L
-328_16.menu.clock.62k_e.build.f_div=256
 
 # Variants
 328_16.menu.variant.modelP=328P-LQFP32
@@ -306,21 +271,6 @@ menu.upload_speed=Upload speed
 328_12.menu.clock.1M_i.build.f_osc=32000000L
 328_12.menu.clock.1M_i.build.f_div=32
 
-328_12.menu.clock.500k_i=Internal 500 kHz
-328_12.menu.clock.500k_i.build.clock_source=1
-328_12.menu.clock.500k_i.build.f_osc=32000000L
-328_12.menu.clock.500k_i.build.f_div=64
-
-328_12.menu.clock.250k_i=Internal 250 kHz
-328_12.menu.clock.250k_i.build.clock_source=1
-328_12.menu.clock.250k_i.build.f_osc=32000000L
-328_12.menu.clock.250k_i.build.f_div=128
-
-328_12.menu.clock.125k_i=Internal 125 kHz
-328_12.menu.clock.125k_i.build.clock_source=1
-328_12.menu.clock.125k_i.build.f_osc=32000000L
-328_12.menu.clock.125k_i.build.f_div=256
-
 328_12.menu.clock.12M_e=External 12 MHz
 328_12.menu.clock.12M_e.build.clock_source=2
 328_12.menu.clock.12M_e.build.f_osc=12000000L
@@ -340,31 +290,6 @@ menu.upload_speed=Upload speed
 328_12.menu.clock.1_5M_e.build.clock_source=2
 328_12.menu.clock.1_5M_e.build.f_osc=12000000L
 328_12.menu.clock.1_5M_e.build.f_div=8
-
-328_12.menu.clock._75M_e=External 750 kHz
-328_12.menu.clock._75M_e.build.clock_source=2
-328_12.menu.clock._75M_e.build.f_osc=12000000L
-328_12.menu.clock._75M_e.build.f_div=16
-
-328_12.menu.clock.375k_e=External 375 kHz
-328_12.menu.clock.375k_e.build.clock_source=2
-328_12.menu.clock.375k_e.build.f_osc=12000000L
-328_12.menu.clock.375k_e.build.f_div=32
-
-328_12.menu.clock.187k_e=External 187.5 kHz
-328_12.menu.clock.187k_e.build.clock_source=2
-328_12.menu.clock.187k_e.build.f_osc=12000000L
-328_12.menu.clock.187k_e.build.f_div=64
-
-328_12.menu.clock.94k_e=External 93.75 kHz
-328_12.menu.clock.94k_e.build.clock_source=2
-328_12.menu.clock.94k_e.build.f_osc=12000000L
-328_12.menu.clock.94k_e.build.f_div=128
-
-328_12.menu.clock.47k_e=External 46.875 kHz
-328_12.menu.clock.47k_e.build.clock_source=2
-328_12.menu.clock.47k_e.build.f_osc=12000000L
-328_12.menu.clock.47k_e.build.f_div=256
 
 # Variants
 328_12.menu.variant.modelP=328P-LQFP32

--- a/lgt8f/boards.txt
+++ b/lgt8f/boards.txt
@@ -218,15 +218,15 @@ menu.upload_speed=Upload speed
 328_16.menu.clock.62k_e.build.f_div=256
 
 # Variants
-328_16.menu.variant.modelP48=328P-LQFP48
-328_16.menu.variant.modelP48.bootloader.path=lgt8fx8p
-328_16.menu.variant.modelP48.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
-328_16.menu.variant.modelP48.build.variant=lgt8fx8p48
-
 328_16.menu.variant.modelP=328P-LQFP32
 328_16.menu.variant.modelP.bootloader.path=lgt8fx8p
 328_16.menu.variant.modelP.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
 328_16.menu.variant.modelP.build.variant=lgt8fx8p
+
+328_16.menu.variant.modelP48=328P-LQFP48
+328_16.menu.variant.modelP48.bootloader.path=lgt8fx8p
+328_16.menu.variant.modelP48.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
+328_16.menu.variant.modelP48.build.variant=lgt8fx8p48
 
 328_16.menu.variant.modelD=328D
 328_16.menu.variant.modelD.bootloader.path=lgt8fx8e
@@ -238,6 +238,8 @@ menu.upload_speed=Upload speed
 328_16.menu.upload_speed.57600.upload.speed=57600
 328_16.menu.upload_speed.115200=115200
 328_16.menu.upload_speed.115200.upload.speed=115200
+328_16.menu.upload_speed.19200=19200
+328_16.menu.upload_speed.19200.upload.speed=19200
 
 ###################################
 #### LGT8F328 + 12 MHz crystal ####
@@ -365,15 +367,15 @@ menu.upload_speed=Upload speed
 328_12.menu.clock.47k_e.build.f_div=256
 
 # Variants
-328_12.menu.variant.modelP48=328P-LQFP48
-328_12.menu.variant.modelP48.bootloader.path=lgt8fx8p
-328_12.menu.variant.modelP48.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
-328_12.menu.variant.modelP48.build.variant=lgt8fx8p48
-
 328_12.menu.variant.modelP=328P-LQFP32
 328_12.menu.variant.modelP.bootloader.path=lgt8fx8p
 328_12.menu.variant.modelP.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
 328_12.menu.variant.modelP.build.variant=lgt8fx8p
+
+328_12.menu.variant.modelP48=328P-LQFP48
+328_12.menu.variant.modelP48.bootloader.path=lgt8fx8p
+328_12.menu.variant.modelP48.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
+328_12.menu.variant.modelP48.build.variant=lgt8fx8p48
 
 328_12.menu.variant.modelD=328D
 328_12.menu.variant.modelD.bootloader.path=lgt8fx8e
@@ -385,6 +387,8 @@ menu.upload_speed=Upload speed
 328_12.menu.upload_speed.57600.upload.speed=57600
 328_12.menu.upload_speed.115200=115200
 328_12.menu.upload_speed.115200.upload.speed=115200
+328_12.menu.upload_speed.19200=19200
+328_12.menu.upload_speed.19200.upload.speed=19200
 
 ############################
 #### Larduino Uno       ####

--- a/lgt8f/boards.txt
+++ b/lgt8f/boards.txt
@@ -6,6 +6,7 @@ menu.clock_source=Clock Source
 menu.clock=Clock
 menu.variant=Variant
 menu.arduino_isp=Arduino as ISP
+menu.upload_speed=Upload speed
 
 #############################
 #### LGT8F328 P/E/S      ####
@@ -27,7 +28,6 @@ menu.arduino_isp=Arduino as ISP
 328.build.board=AVR_LARDU_328E
 
 # Arduino as ISP
- 
 328.menu.arduino_isp.disable=Default (64)
 328.menu.arduino_isp.disable.build.SERIAL_RX_BUFFER_SIZE=64
 328.menu.arduino_isp.enable=[To burn an ISP] SERIAL_RX_BUFFER_SIZE to 250
@@ -80,62 +80,316 @@ menu.arduino_isp=Arduino as ISP
 328.menu.variant.modelP_SSOP20.bootloader.path=lgt8fx8ps20
 328.menu.variant.modelP_SSOP20.bootloader.file=lgt8fx8ps20/optiboot_lgt8f328ps20.hex
 328.menu.variant.modelP_SSOP20.build.variant=lgt8fx8ps20
+
 #328.menu.variant.modelD_SSOP20=328D-SSOP20 (rare)
 #328.menu.variant.modelD_SSOP20.bootloader.path=lgt8fx8e
 #328.menu.variant.modelD_SSOP20.bootloader.file=lgt8fx8e/optiboot_lgt8f328d.hex
 #328.menu.variant.modelD_SSOP20.build.variant=lgt8fx8ds20
 
-############################
-#### LGT8F88            ####
-############################
+# Upload Speeds
+#328.menu.upload_speed.57600=57600
+#328.menu.upload_speed.57600.upload.speed=57600
+#328.menu.upload_speed.115200=115200
+#328.menu.upload_speed.115200.upload.speed=115200
 
-88.name=LGT8F88
-88.upload.tool=avrdude
-88.upload.protocol=arduino
-88.upload.maximum_size=7168
-88.upload.speed=57600
-88.bootloader.tool=avrdude
-88.bootloader.high_fuses=0xff
-88.bootloader.low_fuses=0xff
-88.bootloader.extended_fuses=0x07
-88.bootloader.unlock_bits=0x3f
-88.bootloader.lock_bits=0x3f
-88.build.mcu=atmega88
-88.build.core=lgt8f
-88.build.board=AVR_LARDU_88DS20
+###################################
+#### LGT8F328 + 16 MHz crystal ####
+###################################
+
+328_16.name=LGT8F328 + 16 MHz crystal
+328_16.upload.tool=avrdude
+328_16.upload.protocol=arduino
+328_16.upload.maximum_size=29696
+328_16.upload.speed=57600
+328_16.bootloader.tool=avrdude
+328_16.bootloader.high_fuses=0xff
+328_16.bootloader.low_fuses=0xff
+328_16.bootloader.extended_fuses=0x07
+328_16.bootloader.unlock_bits=0x3f
+328_16.bootloader.lock_bits=0x3f
+328_16.build.core=lgt8f
+328_16.build.mcu=atmega328p
+328_16.build.board=AVR_LARDU_328E
+
+# Arduino as ISP
+328_16.menu.arduino_isp.disable=Default (64)
+328_16.menu.arduino_isp.disable.build.SERIAL_RX_BUFFER_SIZE=64
+328_16.menu.arduino_isp.enable=[To burn an ISP] SERIAL_RX_BUFFER_SIZE to 250
+328_16.menu.arduino_isp.enable.build.SERIAL_RX_BUFFER_SIZE=250
 
 # Clock source
-88.menu.clock_source.internal=Internal
-88.menu.clock_source.internal.build.clock_source=1
-88.menu.clock_source.internal.build.f_osc=32000000L
-88.menu.clock_source.external=External (assumes 32MHz crystal)
-88.menu.clock_source.external.build.clock_source=2
-88.menu.clock_source.external.build.f_osc=32000000L
+#328_16.menu.clock_source.internal=Nothing here
+#328_16.menu.clock_source.internal=Internal 32 MHz
+#328_16.menu.clock_source.internal.build.clock_source=1
+#328_16.menu.clock_source.internal.build.f_osc=32000000L
+#328_16.menu.clock_source.external=External 16 MHz crystal
+#328_16.menu.clock_source.external.build.clock_source=2
+#328_16.menu.clock_source.external.build.f_osc=16000000L
 
 # Clock frequencies
-88.menu.clock.32MHz=32 MHz
-88.menu.clock.32MHz.build.f_div=1
-88.menu.clock.16MHz=16 MHz
-88.menu.clock.16MHz.build.f_div=2
-88.menu.clock.8MHz=8 MHz
-88.menu.clock.8MHz.build.f_div=4
-88.menu.clock.4MHz=4 MHz
-88.menu.clock.4MHz.build.f_div=8
-88.menu.clock.2MHz=2 MHz
-88.menu.clock.2MHz.build.f_div=16
-88.menu.clock.1MHz=1 MHz
-88.menu.clock.1MHz.build.f_div=32
+328_16.menu.clock.32M_i=Internal 32 MHz (Not for 328D)
+328_16.menu.clock.32M_i.build.clock_source=1
+328_16.menu.clock.32M_i.build.f_osc=32000000L
+328_16.menu.clock.32M_i.build.f_div=1
+
+328_16.menu.clock.16M_i=Internal 16 MHz
+328_16.menu.clock.16M_i.build.clock_source=1
+328_16.menu.clock.16M_i.build.f_osc=32000000L
+328_16.menu.clock.16M_i.build.f_div=2
+
+328_16.menu.clock.8M_i=Internal 8 MHz
+328_16.menu.clock.8M_i.build.clock_source=1
+328_16.menu.clock.8M_i.build.f_osc=32000000L
+328_16.menu.clock.8M_i.build.f_div=4
+
+328_16.menu.clock.4M_i=Internal 4 MHz
+328_16.menu.clock.4M_i.build.clock_source=1
+328_16.menu.clock.4M_i.build.f_osc=32000000L
+328_16.menu.clock.4M_i.build.f_div=8
+
+328_16.menu.clock.2M_i=Internal 2 MHz
+328_16.menu.clock.2M_i.build.clock_source=1
+328_16.menu.clock.2M_i.build.f_osc=32000000L
+328_16.menu.clock.2M_i.build.f_div=16
+
+328_16.menu.clock.1M_i=Internal 1 MHz
+328_16.menu.clock.1M_i.build.clock_source=1
+328_16.menu.clock.1M_i.build.f_osc=32000000L
+328_16.menu.clock.1M_i.build.f_div=32
+
+328_16.menu.clock.500k_i=Internal 500 kHz
+328_16.menu.clock.500k_i.build.clock_source=1
+328_16.menu.clock.500k_i.build.f_osc=32000000L
+328_16.menu.clock.500k_i.build.f_div=64
+
+328_16.menu.clock.250k_i=Internal 250 kHz
+328_16.menu.clock.250k_i.build.clock_source=1
+328_16.menu.clock.250k_i.build.f_osc=32000000L
+328_16.menu.clock.250k_i.build.f_div=128
+
+328_16.menu.clock.125k_i=Internal 125 kHz
+328_16.menu.clock.125k_i.build.clock_source=1
+328_16.menu.clock.125k_i.build.f_osc=32000000L
+328_16.menu.clock.125k_i.build.f_div=256
+
+328_16.menu.clock.16M_e=External 16 MHz
+328_16.menu.clock.16M_e.build.clock_source=2
+328_16.menu.clock.16M_e.build.f_osc=16000000L
+328_16.menu.clock.16M_e.build.f_div=1
+
+328_16.menu.clock.8M_e=External 8 MHz
+328_16.menu.clock.8M_e.build.clock_source=2
+328_16.menu.clock.8M_e.build.f_osc=16000000L
+328_16.menu.clock.8M_e.build.f_div=2
+
+328_16.menu.clock.4M_e=External 4 MHz
+328_16.menu.clock.4M_e.build.clock_source=2
+328_16.menu.clock.4M_e.build.f_osc=16000000L
+328_16.menu.clock.4M_e.build.f_div=4
+
+328_16.menu.clock.2M_e=External 2 MHz
+328_16.menu.clock.2M_e.build.clock_source=2
+328_16.menu.clock.2M_e.build.f_osc=16000000L
+328_16.menu.clock.2M_e.build.f_div=8
+
+328_16.menu.clock.1M_e=External 1 MHz
+328_16.menu.clock.1M_e.build.clock_source=2
+328_16.menu.clock.1M_e.build.f_osc=16000000L
+328_16.menu.clock.1M_e.build.f_div=16
+
+328_16.menu.clock.500k_e=External 500 kHz
+328_16.menu.clock.500k_e.build.clock_source=2
+328_16.menu.clock.500k_e.build.f_osc=16000000L
+328_16.menu.clock.500k_e.build.f_div=32
+
+328_16.menu.clock.250k_e=External 250 kHz
+328_16.menu.clock.250k_e.build.clock_source=2
+328_16.menu.clock.250k_e.build.f_osc=16000000L
+328_16.menu.clock.250k_e.build.f_div=64
+
+328_16.menu.clock.125k_e=External 125 kHz
+328_16.menu.clock.125k_e.build.clock_source=2
+328_16.menu.clock.125k_e.build.f_osc=16000000L
+328_16.menu.clock.125k_e.build.f_div=128
+
+328_16.menu.clock.62k_e=External 62.5 kHz
+328_16.menu.clock.62k_e.build.clock_source=2
+328_16.menu.clock.62k_e.build.f_osc=16000000L
+328_16.menu.clock.62k_e.build.f_div=256
 
 # Variants
-88.menu.variant.modelD=LGT8F88D-SSOP20
-88.menu.variant.modelD.bootloader.path=lgt8fx8ds20
-88.menu.variant.modelD.bootloader.file=lgt8fx8ds20/optiboot_lgt8f88ds20.hex
-88.menu.variant.modelD.build.variant=lgt8fx8ds20
+328_16.menu.variant.modelP48=328P-LQFP48
+328_16.menu.variant.modelP48.bootloader.path=lgt8fx8p
+328_16.menu.variant.modelP48.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
+328_16.menu.variant.modelP48.build.variant=lgt8fx8p48
+
+328_16.menu.variant.modelP=328P-LQFP32
+328_16.menu.variant.modelP.bootloader.path=lgt8fx8p
+328_16.menu.variant.modelP.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
+328_16.menu.variant.modelP.build.variant=lgt8fx8p
+
+328_16.menu.variant.modelD=328D
+328_16.menu.variant.modelD.bootloader.path=lgt8fx8e
+328_16.menu.variant.modelD.bootloader.file=lgt8fx8e/optiboot_lgt8f328d.hex
+328_16.menu.variant.modelD.build.variant=lgt8fx8e
+
+# Upload Speeds
+328_16.menu.upload_speed.57600=57600
+328_16.menu.upload_speed.57600.upload.speed=57600
+328_16.menu.upload_speed.115200=115200
+328_16.menu.upload_speed.115200.upload.speed=115200
+
+###################################
+#### LGT8F328 + 12 MHz crystal ####
+###################################
+
+328_12.name=LGT8F328 + 12 MHz crystal
+328_12.upload.tool=avrdude
+328_12.upload.protocol=arduino
+328_12.upload.maximum_size=29696
+328_12.upload.speed=57600
+328_12.bootloader.tool=avrdude
+328_12.bootloader.high_fuses=0xff
+328_12.bootloader.low_fuses=0xff
+328_12.bootloader.extended_fuses=0x07
+328_12.bootloader.unlock_bits=0x3f
+328_12.bootloader.lock_bits=0x3f
+328_12.build.core=lgt8f
+328_12.build.mcu=atmega328p
+328_12.build.board=AVR_LARDU_328E
+
+# Arduino as ISP
+328_12.menu.arduino_isp.disable=Default (64)
+328_12.menu.arduino_isp.disable.build.SERIAL_RX_BUFFER_SIZE=64
+328_12.menu.arduino_isp.enable=[To burn an ISP] SERIAL_RX_BUFFER_SIZE to 250
+328_12.menu.arduino_isp.enable.build.SERIAL_RX_BUFFER_SIZE=250
+
+# Clock source
+#328_12.menu.clock_source.internal=Nothing here
+#328_12.menu.clock_source.internal=Internal 32 MHz
+#328_12.menu.clock_source.internal.build.clock_source=1
+#328_12.menu.clock_source.internal.build.f_osc=32000000L
+#328_12.menu.clock_source.external=External 12 MHz crystal
+#328_12.menu.clock_source.external.build.clock_source=2
+#328_12.menu.clock_source.external.build.f_osc=12000000L
+
+# Clock frequencies
+328_12.menu.clock.32M_i=Internal 32 MHz (Not for 328D)
+328_12.menu.clock.32M_i.build.clock_source=1
+328_12.menu.clock.32M_i.build.f_osc=32000000L
+328_12.menu.clock.32M_i.build.f_div=1
+
+328_12.menu.clock.16M_i=Internal 16 MHz
+328_12.menu.clock.16M_i.build.clock_source=1
+328_12.menu.clock.16M_i.build.f_osc=32000000L
+328_12.menu.clock.16M_i.build.f_div=2
+
+328_12.menu.clock.8M_i=Internal 8 MHz
+328_12.menu.clock.8M_i.build.clock_source=1
+328_12.menu.clock.8M_i.build.f_osc=32000000L
+328_12.menu.clock.8M_i.build.f_div=4
+
+328_12.menu.clock.4M_i=Internal 4 MHz
+328_12.menu.clock.4M_i.build.clock_source=1
+328_12.menu.clock.4M_i.build.f_osc=32000000L
+328_12.menu.clock.4M_i.build.f_div=8
+
+328_12.menu.clock.2M_i=Internal 2 MHz
+328_12.menu.clock.2M_i.build.clock_source=1
+328_12.menu.clock.2M_i.build.f_osc=32000000L
+328_12.menu.clock.2M_i.build.f_div=16
+
+328_12.menu.clock.1M_i=Internal 1 MHz
+328_12.menu.clock.1M_i.build.clock_source=1
+328_12.menu.clock.1M_i.build.f_osc=32000000L
+328_12.menu.clock.1M_i.build.f_div=32
+
+328_12.menu.clock.500k_i=Internal 500 kHz
+328_12.menu.clock.500k_i.build.clock_source=1
+328_12.menu.clock.500k_i.build.f_osc=32000000L
+328_12.menu.clock.500k_i.build.f_div=64
+
+328_12.menu.clock.250k_i=Internal 250 kHz
+328_12.menu.clock.250k_i.build.clock_source=1
+328_12.menu.clock.250k_i.build.f_osc=32000000L
+328_12.menu.clock.250k_i.build.f_div=128
+
+328_12.menu.clock.125k_i=Internal 125 kHz
+328_12.menu.clock.125k_i.build.clock_source=1
+328_12.menu.clock.125k_i.build.f_osc=32000000L
+328_12.menu.clock.125k_i.build.f_div=256
+
+328_12.menu.clock.12M_e=External 12 MHz
+328_12.menu.clock.12M_e.build.clock_source=2
+328_12.menu.clock.12M_e.build.f_osc=12000000L
+328_12.menu.clock.12M_e.build.f_div=1
+
+328_12.menu.clock.6M_e=External 6 MHz
+328_12.menu.clock.6M_e.build.clock_source=2
+328_12.menu.clock.6M_e.build.f_osc=12000000L
+328_12.menu.clock.6M_e.build.f_div=2
+
+328_12.menu.clock.3M_e=External 3 MHz
+328_12.menu.clock.3M_e.build.clock_source=2
+328_12.menu.clock.3M_e.build.f_osc=12000000L
+328_12.menu.clock.3M_e.build.f_div=4
+
+328_12.menu.clock.1_5M_e=External 1.5 MHz
+328_12.menu.clock.1_5M_e.build.clock_source=2
+328_12.menu.clock.1_5M_e.build.f_osc=12000000L
+328_12.menu.clock.1_5M_e.build.f_div=8
+
+328_12.menu.clock._75M_e=External 750 kHz
+328_12.menu.clock._75M_e.build.clock_source=2
+328_12.menu.clock._75M_e.build.f_osc=12000000L
+328_12.menu.clock._75M_e.build.f_div=16
+
+328_12.menu.clock.375k_e=External 375 kHz
+328_12.menu.clock.375k_e.build.clock_source=2
+328_12.menu.clock.375k_e.build.f_osc=12000000L
+328_12.menu.clock.375k_e.build.f_div=32
+
+328_12.menu.clock.187k_e=External 187.5 kHz
+328_12.menu.clock.187k_e.build.clock_source=2
+328_12.menu.clock.187k_e.build.f_osc=12000000L
+328_12.menu.clock.187k_e.build.f_div=64
+
+328_12.menu.clock.94k_e=External 93.75 kHz
+328_12.menu.clock.94k_e.build.clock_source=2
+328_12.menu.clock.94k_e.build.f_osc=12000000L
+328_12.menu.clock.94k_e.build.f_div=128
+
+328_12.menu.clock.47k_e=External 46.875 kHz
+328_12.menu.clock.47k_e.build.clock_source=2
+328_12.menu.clock.47k_e.build.f_osc=12000000L
+328_12.menu.clock.47k_e.build.f_div=256
+
+# Variants
+328_12.menu.variant.modelP48=328P-LQFP48
+328_12.menu.variant.modelP48.bootloader.path=lgt8fx8p
+328_12.menu.variant.modelP48.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
+328_12.menu.variant.modelP48.build.variant=lgt8fx8p48
+
+328_12.menu.variant.modelP=328P-LQFP32
+328_12.menu.variant.modelP.bootloader.path=lgt8fx8p
+328_12.menu.variant.modelP.bootloader.file=lgt8fx8p/optiboot_lgt8f328p.hex
+328_12.menu.variant.modelP.build.variant=lgt8fx8p
+
+328_12.menu.variant.modelD=328D
+328_12.menu.variant.modelD.bootloader.path=lgt8fx8e
+328_12.menu.variant.modelD.bootloader.file=lgt8fx8e/optiboot_lgt8f328d.hex
+328_12.menu.variant.modelD.build.variant=lgt8fx8e
+
+# Upload Speeds
+328_12.menu.upload_speed.57600=57600
+328_12.menu.upload_speed.57600.upload.speed=57600
+328_12.menu.upload_speed.115200=115200
+328_12.menu.upload_speed.115200.upload.speed=115200
 
 ############################
 #### Larduino Uno       ####
 ############################
-lardu_328e.name= Larduino Uno
+lardu_328e.name=Larduino Uno
 lardu_328e.upload.tool=avrdude
 lardu_328e.upload.protocol=arduino
 lardu_328e.upload.maximum_size=29696

--- a/lgt8f/boards.txt
+++ b/lgt8f/boards.txt
@@ -286,11 +286,6 @@ menu.upload_speed=Upload speed
 328_12.menu.clock.3M_e.build.f_osc=12000000L
 328_12.menu.clock.3M_e.build.f_div=4
 
-328_12.menu.clock.1_5M_e=External 1.5 MHz
-328_12.menu.clock.1_5M_e.build.clock_source=2
-328_12.menu.clock.1_5M_e.build.f_osc=12000000L
-328_12.menu.clock.1_5M_e.build.f_div=8
-
 # Variants
 328_12.menu.variant.modelP=328P-LQFP32
 328_12.menu.variant.modelP.bootloader.path=lgt8fx8p

--- a/lgt8f/cores/lgt8f/main.cpp
+++ b/lgt8f/cores/lgt8f/main.cpp
@@ -144,7 +144,9 @@ void lgt8fx8x_clk_src()
 
 // select clock prescaler
 #if defined(F_CPU) && defined(F_OSC)
+#if !defined(F_DIV)
 #define F_DIV	(F_OSC / F_CPU)
+#endif
     CLKPR = 0x80;
     #if F_DIV <= 1
         CLKPR = 0x00;

--- a/lgt8f/cores/lgt8f/main.cpp
+++ b/lgt8f/cores/lgt8f/main.cpp
@@ -106,6 +106,7 @@ void lgt8fx8x_init()
 	ECCR = 0x40;
 
 // clock source settings
+#if !defined(CLOCK_SOURCE)
 	if((VDTCR & 0x0C) == 0x0C) {
 		// switch to external crystal
 		sysClock(EXT_OSC);
@@ -113,15 +114,18 @@ void lgt8fx8x_init()
 		CLKPR = 0x80;
 		CLKPR = 0x01;
 	}
+#endif // CLOCK_SOURCE
 #else
 	// enable 32KRC for WDT
 	GPIOR0 = PMCR | 0x10;
 	PMCR = 0x80;
 	PMCR = GPIOR0;
 
+#if !defined(CLOCK_SOURCE)
 	// clock scalar to 16MHz
 	CLKPR = 0x80;
 	CLKPR = 0x01;
+#endif // CLOCK_SOURCE
 #endif
 }
 
@@ -130,29 +134,36 @@ void lgt8fx8x_clk_src()
 {
 // select clock source
 #if defined(CLOCK_SOURCE)
+    // override bootloader setting
     #if CLOCK_SOURCE == 1
-        // internal clock is default, do nothing
-        // sysClock(INT_OSC);
+        sysClock(INT_OSC);
     #elif CLOCK_SOURCE == 2
         sysClock(EXT_OSC);
     #endif
 #endif
 
 // select clock prescaler
-#if defined(F_CPU)
+#if defined(F_CPU) && defined(F_OSC)
+#define F_DIV	(F_OSC / F_CPU)
     CLKPR = 0x80;
-    #if F_CPU == 32000000L
+    #if F_DIV <= 1
         CLKPR = 0x00;
-    #elif F_CPU == 16000000L
+    #elif F_DIV <= 2
         CLKPR = 0x01;
-    #elif F_CPU == 8000000L
+    #elif F_DIV <= 4
         CLKPR = 0x02;
-    #elif F_CPU == 4000000L
+    #elif F_DIV <= 8
         CLKPR = 0x03;
-    #elif F_CPU == 2000000L
+    #elif F_DIV <= 16
         CLKPR = 0x04;
-    #elif F_CPU == 1000000L
+    #elif F_DIV <= 32
         CLKPR = 0x05;
+    #elif F_DIV <= 64
+        CLKPR = 0x06;
+    #elif F_DIV <= 128
+        CLKPR = 0x07;
+    #elif
+        CLKPR = 0x08;
     #endif
 #endif
 }

--- a/lgt8f/platform.txt
+++ b/lgt8f/platform.txt
@@ -51,13 +51,13 @@ compiler.elf2hex.extra_flags=
 # --------------------
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DF_OSC={build.f_osc} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DF_OSC={build.f_osc} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
-recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DF_OSC={build.f_osc} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 # archive_file_path is needed for backwards compatibility with IDE 1.6.5 or older, IDE 1.6.6 or newer overrides this value
@@ -83,10 +83,10 @@ recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 
 ## Preprocessor
 preproc.includes.flags=-w -x c++ -M -MG -MP
-recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
+recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DF_OSC={build.f_osc} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
 
 preproc.macros.flags=-w -x c++ -E -CC
-recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
+recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DF_OSC={build.f_osc} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
 
 # AVR Uploader/Programmers tools
 # ------------------------------

--- a/lgt8f/platform.txt
+++ b/lgt8f/platform.txt
@@ -51,13 +51,13 @@ compiler.elf2hex.extra_flags=
 # --------------------
 
 ## Compile c files
-recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DF_OSC={build.f_osc} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU=({build.f_osc}/{build.f_div}) -DF_OSC={build.f_osc} -DF_DIV={build.f_div} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DF_OSC={build.f_osc} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU=({build.f_osc}/{build.f_div}) -DF_OSC={build.f_osc} -DF_DIV={build.f_div} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
-recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DF_OSC={build.f_osc} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
+recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU=({build.f_osc}/{build.f_div}) -DF_OSC={build.f_osc} -DF_DIV={build.f_div} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
 # archive_file_path is needed for backwards compatibility with IDE 1.6.5 or older, IDE 1.6.6 or newer overrides this value
@@ -83,10 +83,10 @@ recipe.size.regex.eeprom=^(?:\.eeprom)\s+([0-9]+).*
 
 ## Preprocessor
 preproc.includes.flags=-w -x c++ -M -MG -MP
-recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DF_OSC={build.f_osc} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
+recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU=({build.f_osc}/{build.f_div}) -DF_OSC={build.f_osc} -DF_DIV={build.f_div} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
 
 preproc.macros.flags=-w -x c++ -E -CC
-recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU={build.f_cpu} -DF_OSC={build.f_osc} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
+recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DSERIAL_RX_BUFFER_SIZE={build.SERIAL_RX_BUFFER_SIZE} -DCLOCK_SOURCE={build.clock_source} -DF_CPU=({build.f_osc}/{build.f_div}) -DF_OSC={build.f_osc} -DF_DIV={build.f_div} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
 
 # AVR Uploader/Programmers tools
 # ------------------------------


### PR DESCRIPTION
Oscillator clock is assumed as 32MHz (internal or external), but this makes difficult to support the board that has 16MHz external xtal; MassDuino UNO R3.

Add F_OSC, oscillator clock definition. To determine clock divisior, use F_OSC and F_CPU value.

Also, problem with using external clock (bootloader) and internal clock (sketch) is fixed.