### PR TITLE
Correcting ADMUX selection in __analogRead()

### DIFF
--- a/lgt8f/cores/lgt8f/wiring_analog.c
+++ b/lgt8f/cores/lgt8f/wiring_analog.c
@@ -25,8 +25,8 @@
 #include "wiring_private.h"
 #include "pins_arduino.h"
 
-uint8_t analog_resbit = 0;
-uint8_t analog_resdir = 0;
+uint8_t analog_resbit = 2;
+uint8_t analog_resdir = 1;
 uint8_t analog_reference = DEFAULT;
 
 #if defined(__LGT8F__)

--- a/lgt8f/cores/lgt8f/wiring_analog.c
+++ b/lgt8f/cores/lgt8f/wiring_analog.c
@@ -111,7 +111,7 @@ static int __analogRead(uint8_t pin)
 	
 	// enable/disable internal 1/5VCC channel
 	ADCSRD &= 0xf0;
-	if(pin == V5D1 || pin == V5D4) { 
+	if(pin == V5D1 || pin == V5D4 || pin == VCCM) { 
 		ADCSRD |= 0x06;
 	}	
 #endif
@@ -144,7 +144,14 @@ static int __analogRead(uint8_t pin)
 #if defined(__AVR_ATtiny25__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)
 	ADMUX = (analog_reference << 4) | (pin & 0x07);
 #else
+  #if defined(__LGT8F__)
+    #if defined(__LGT8FX8E__)
+	if (( pin >= 9 && pin <= 12 )) || ( pin >= 16 )) return 0;   // invalid ADMUX selection in LGT8F328D
+    #endif
+	ADMUX = (analog_reference << 6) | (pin & 0x1f);
+  #else
 	ADMUX = (analog_reference << 6) | (pin & 0x07);
+  #endif
 #endif
 #endif
 

--- a/lgt8f/cores/lgt8f/wiring_analog.c
+++ b/lgt8f/cores/lgt8f/wiring_analog.c
@@ -146,7 +146,7 @@ static int __analogRead(uint8_t pin)
 #else
   #if defined(__LGT8F__)
     #if defined(__LGT8FX8E__)
-	if (( pin >= 9 && pin <= 12 )) || ( pin >= 16 )) return 0;   // invalid ADMUX selection in LGT8F328D
+	if (( pin >= 9 && pin <= 12 ) || ( pin >= 16 )) return 0;   // invalid ADMUX selection in LGT8F328D
     #endif
 	ADMUX = (analog_reference << 6) | (pin & 0x1f);
   #else


### PR DESCRIPTION
- ADMUX input source used a wrong mask. (was 0x0f instead 0x1f)
- LGT8F328D ADMUX has less input than P version. If someone want to read these unselectable inputs, it will return zero ADC value.
- V5D1 and VCCM is same input with different name