### PR TITLE
Fixed powerDown-Dps2.ino

### DIFF
--- a/lgt8f/libraries/lgt_LowPower/examples/powerDown-Dps2/powerDown-Dps2.ino
+++ b/lgt8f/libraries/lgt_LowPower/examples/powerDown-Dps2/powerDown-Dps2.ino
@@ -7,8 +7,8 @@
  * retention. After wake up the chip will perform a complete power-on reset.   *
  * Wake up sources are: port D pin level change( INT0, INT1, RXD, TXD, etc) or *
  * Low Power RC timer or Reset pin.                                            *
- * Available durations for this low power mode: about 128, 256, 512, 2500 ms   *
- *                                                    and     SLEEP_FOREVER    *
+ * Available durations for this low power mode: about 128 ms, 256 ms, 512 ms,  *
+ * 1 s and SLEEP_FOREVER.                                                      *
  *******************************************************************************
  * LGT8F328D does not have DPS2 sleep mode.                                    *
  *******************************************************************************/
@@ -25,11 +25,10 @@ void loop()
     delay(4000);
 
     // Set which pins should be the wake-up pins
-    IOCWK = PORTD2 | PORTD4;
+    IOCWK = (1<<PORTD2) | (1<<PORTD4);
 
-    // Enter deep sleep state for > 2 s
+    // Enter deep sleep state for < 2 s or forever
     LowPower.deepSleep2(SLEEP_1S);
 
-    // No code executiion after deepSleep2
+    // No code execution after deepSleep2
 }
-

--- a/lgt8f/libraries/lgt_LowPower/readme.md
+++ b/lgt8f/libraries/lgt_LowPower/readme.md
@@ -82,14 +82,14 @@ Basic usage:
   The Pin Change and Interrupt module uses the I/O clock which is halted in all sleep modes except Idle mode, like ATmega328 does. <br>
 <br>
 
-`LowPower.adcNoiseReduction(SLEEP_period, ADC_ON, BOD_OFF, TIMER2_OFF )` <br>
+`LowPower.adcNoiseReduction( SLEEP_period, ADC_ON, TIMER2_OFF )` <br>
   --Putting microcontroller into ADC noise reduction state. <br>
   (Turning off the ADC module is basically removing the purpose of this low power mode.) <br>
 <br>
 
  _--The functions below stops the clocks of peripherial modules so there's no point to left under powered modules during sleep which has no clock, like ADC._
 
-`LowPower.powerExtStandby(SLEEP_period, ADC_OFF, BOD_OFF, TIMER2_OFF )` <br>
+`LowPower.powerExtStandby( SLEEP_period, ADC_OFF, BOD_OFF, TIMER2_OFF )` <br>
   --LGT8F power save sleep mode <br>
   --Wake up sources: Watchdog, External interrupt 0/1, Pin Change Interrupt, Timer2, Two-Wire serial Interface address match, External reset <br>
 <br>
@@ -99,7 +99,7 @@ Basic usage:
   --Wake up sources: Watchdog, External interrupt 0/1, Pin Change Interrupt, Timer2, Two-Wire serial Interface address match, External reset <br>
 <br>
 
-`LowPower.powerDown(SLEEP_period, ADC_OFF, BOD_OFF, TIMER2_OFF )` <br>
+`LowPower.powerDown( SLEEP_period, ADC_OFF, BOD_OFF )` <br>
   --LGT8F **D**ee**P** **S**leep mode **1** <br>
   --Same as DSP0, but since of all system clock are turned off the INT0, INT1 edge detect interrupts not working.<br>
   --Wake up sources: Watchdog, External level interrupt 0/1, Port D level change, Timer2. <br>


### PR DESCRIPTION
Found a bug in powerDown-Dps2.ino:
IOCWK = PORTD2) | PORTD4); 

should be 

IOCWK = (1<<PORTD2) | (1<<PORTD4); 

And some issues in the comments.  
