### PR TITLE
Adding Timer3 related PWM analogWrite for D1 and D2

### DIFF
--- a/lgt8f/cores/lgt8f/wiring_analog.c
+++ b/lgt8f/cores/lgt8f/wiring_analog.c
@@ -309,8 +309,7 @@ void analogWrite(uint8_t pin, int val)
 			case TIMER3A:
 				// connect pwm to pin on timer 3, channel A
 				// and switch pin data direction of PORTD to input and PORTE to output
-				TCCR3A |= 1 << COM3A1 | 1 << WGM30;
-				TCCR3B  = 1 << WGM32  | 1 << CS30;
+				sbi(TCCR3A,COM3A1);
 				#if !defined(__LGT8FX8P48__)
 				cbi(DDRD,DDD1);
 				#endif
@@ -323,8 +322,7 @@ void analogWrite(uint8_t pin, int val)
 			case TIMER3B:
 				// connect pwm to pin on timer 3, channel B
 				// and switch pin data direction of PORTD to input and PORTE to output
-				TCCR3A |= 1 << COM3B1 | 1 << WGM30;
-				TCCR3B  = 1 << WGM32  | 1 << CS30;
+				sbi(TCCR3A,COM3B1);
 				#if !defined(__LGT8FX8P48__)
 				cbi(DDRD,DDD2);
 				#endif
@@ -336,8 +334,6 @@ void analogWrite(uint8_t pin, int val)
 			#if defined(TCCR3A) && defined(COM3C1)
 			case TIMER3C:
 				// connect pwm to pin on timer 3, channel C
-				TCCR3A |= 1 << COM3C1 | 1 << WGM30;
-				TCCR3B  = 1 << WGM32  | 1 << CS30;
 				sbi(TCCR3A, COM3C1);
 				sbi(DDRF,DDF3);
 				OCR3C = val; // set pwm duty

--- a/lgt8f/cores/lgt8f/wiring_analog.c
+++ b/lgt8f/cores/lgt8f/wiring_analog.c
@@ -311,7 +311,10 @@ void analogWrite(uint8_t pin, int val)
 				// and switch pin data direction of PORTD to input and PORTE to output
 				TCCR3A |= 1 << COM3A1 | 1 << WGM30;
 				TCCR3B  = 1 << WGM32  | 1 << CS30;
-				if (DDRD&&(1<<DDD1)) { cbi(DDRD,DDD1); sbi(DDRF,DDF1);}
+				#if !defined(__LGT8FX8P48__)
+				cbi(DDRD,DDD1);
+				#endif
+				sbi(DDRF,DDF1);
 				OCR3A = val; // set pwm duty
 				break;
 			#endif
@@ -322,7 +325,10 @@ void analogWrite(uint8_t pin, int val)
 				// and switch pin data direction of PORTD to input and PORTE to output
 				TCCR3A |= 1 << COM3B1 | 1 << WGM30;
 				TCCR3B  = 1 << WGM32  | 1 << CS30;
-				if (DDRD&&(1<<DDD2)) { cbi(DDRD,DDD2); sbi(DDRF,DDF2);}
+				#if !defined(__LGT8FX8P48__)
+				cbi(DDRD,DDD2);
+				#endif
+				sbi(DDRF,DDF2);
 				OCR3B = val; // set pwm duty
 				break;
 			#endif
@@ -330,7 +336,10 @@ void analogWrite(uint8_t pin, int val)
 			#if defined(TCCR3A) && defined(COM3C1)
 			case TIMER3C:
 				// connect pwm to pin on timer 3, channel C
+				TCCR3A |= 1 << COM3C1 | 1 << WGM30;
+				TCCR3B  = 1 << WGM32  | 1 << CS30;
 				sbi(TCCR3A, COM3C1);
+				sbi(DDRF,DDF3);
 				OCR3C = val; // set pwm duty
 				break;
 			#endif

--- a/lgt8f/cores/lgt8f/wiring_analog.c
+++ b/lgt8f/cores/lgt8f/wiring_analog.c
@@ -308,7 +308,10 @@ void analogWrite(uint8_t pin, int val)
 			#if defined(TCCR3A) && defined(COM3A1)
 			case TIMER3A:
 				// connect pwm to pin on timer 3, channel A
-				sbi(TCCR3A, COM3A1);
+				// and switch pin data direction of PORTD to input and PORTE to output
+				TCCR3A |= 1 << COM3A1 | 1 << WGM30;
+				TCCR3B  = 1 << WGM32  | 1 << CS30;
+				if (DDRD&&(1<<DDD1)) { cbi(DDRD,DDD1); sbi(DDRF,DDF1);}
 				OCR3A = val; // set pwm duty
 				break;
 			#endif
@@ -316,7 +319,10 @@ void analogWrite(uint8_t pin, int val)
 			#if defined(TCCR3A) && defined(COM3B1)
 			case TIMER3B:
 				// connect pwm to pin on timer 3, channel B
-				sbi(TCCR3A, COM3B1);
+				// and switch pin data direction of PORTD to input and PORTE to output
+				TCCR3A |= 1 << COM3B1 | 1 << WGM30;
+				TCCR3B  = 1 << WGM32  | 1 << CS30;
+				if (DDRD&&(1<<DDD2)) { cbi(DDRD,DDD2); sbi(DDRF,DDF2);}
 				OCR3B = val; // set pwm duty
 				break;
 			#endif

--- a/lgt8f/cores/lgt8f/wiring_digital.c
+++ b/lgt8f/cores/lgt8f/wiring_digital.c
@@ -134,10 +134,10 @@ static void turnOffPWM(uint8_t timer)
 		#endif
 		
 		#if defined(TCCR3A) && defined(COM3A1)
-		case  TIMER3A:  cbi(TCCR3A, COM3A1);    break;
+		case  TIMER3A:  cbi(TCCR3A, COM3A1); if (DDRF&&(1<<DDF1)) { cbi(DDRF,DDF1); sbi(DDRD,DDD1); }; break;
 		#endif
 		#if defined(TCCR3A) && defined(COM3B1)
-		case  TIMER3B:  cbi(TCCR3A, COM3B1);    break;
+		case  TIMER3B:  cbi(TCCR3A, COM3B1); if (DDRF&&(1<<DDF2)) { cbi(DDRF,DDF2); sbi(DDRD,DDD2); }; break;
 		#endif
 		#if defined(TCCR3A) && defined(COM3C1)
 		case  TIMER3C:  cbi(TCCR3A, COM3C1);    break;

--- a/lgt8f/cores/lgt8f/wiring_digital.c
+++ b/lgt8f/cores/lgt8f/wiring_digital.c
@@ -134,10 +134,22 @@ static void turnOffPWM(uint8_t timer)
 		#endif
 		
 		#if defined(TCCR3A) && defined(COM3A1)
-		case  TIMER3A:  cbi(TCCR3A, COM3A1); if (DDRF&&(1<<DDF1)) { cbi(DDRF,DDF1); sbi(DDRD,DDD1); }; break;
+		case  TIMER3A:  cbi(TCCR3A, COM3A1);
+				#if !defined(__LGT8FX8P48__)
+				// SSOP20+LQFP32 share a common pin for D1(digital)+F1(timer3a), but uses analogWrite(D1)
+				// if timer via F1 was connected to pin, switch roles: revert F1 to input and D1 to output
+				if (DDRF&(1<<DDF1)) { cbi(DDRF,DDF1); sbi(DDRD,DDD1); };
+				#endif
+				break;
 		#endif
 		#if defined(TCCR3A) && defined(COM3B1)
-		case  TIMER3B:  cbi(TCCR3A, COM3B1); if (DDRF&&(1<<DDF2)) { cbi(DDRF,DDF2); sbi(DDRD,DDD2); }; break;
+		case  TIMER3B:  cbi(TCCR3A, COM3B1); 
+				#if !defined(__LGT8FX8P48__)
+				// SSOP20+LQFP32 share a common pin for D2(digital)+F2(timer3b), but uses analogWrite(D2)
+				// if timer via F2 was connected to pin, switch roles: revert F2 to input and D2 to output
+				if (DDRF&(1<<DDF2)) { cbi(DDRF,DDF2); sbi(DDRD,DDD2); };
+				#endif
+				break;
 		#endif
 		#if defined(TCCR3A) && defined(COM3C1)
 		case  TIMER3C:  cbi(TCCR3A, COM3C1);    break;

--- a/lgt8f/variants/standard/pins_arduino.h
+++ b/lgt8f/variants/standard/pins_arduino.h
@@ -406,55 +406,76 @@ const uint8_t PROGMEM port_to_PCMSK_PGM[] = { 0, 0, 0xFF & (uint16_t)&PCMSK0, 0x
 #endif
 
 const uint8_t PROGMEM digital_pin_to_timer_PGM[] = {
-	NOT_ON_TIMER, /* 0 - port D */
-#if defined(__LGT8FX8E__) || defined(__LGT8FX8P__)
-	TIMER3A,
-	TIMER3B,
+	NOT_ON_TIMER, /* 0 - port D0 */
+#if ( defined(__LGT8FX8E__) || defined(__LGT8FX8P__) ) && !defined(__LGT8FX8P48__)
+	TIMER3A,      /* 1 - port D1 */
+	TIMER3B,      /* 2 - port D2 */
 #else
-	NOT_ON_TIMER,
-	NOT_ON_TIMER,
+	NOT_ON_TIMER, /* 1 - port D1 */
+	NOT_ON_TIMER, /* 2 - port D2 */
 #endif
 	// on the ATmega168, digital pin 3 has hardware pwm
 #if defined(__AVR_ATmega8__)
-	NOT_ON_TIMER,
+	NOT_ON_TIMER, /* 3 - port D3 */
 #else
-	TIMER2B,
+	TIMER2B,      /* 3 - port D3 */
 #endif
 #if defined(__LGT8FX8E__) || defined(__LGT8FX8P__)
-	LGTDAO0,
+	LGTDAO0,      /* 4 - port D4 */
 #else
-	NOT_ON_TIMER,
+	NOT_ON_TIMER, /* 4 - port D4 */
 #endif
 	// on the ATmega168, digital pins 5 and 6 have hardware pwm
 #if defined(__AVR_ATmega8__)
-	NOT_ON_TIMER,
-	NOT_ON_TIMER,
+	NOT_ON_TIMER, /* 5 - port D5 */
+	NOT_ON_TIMER, /* 6 - port D6 */
 #else
-	TIMER0B,
-	TIMER0A,
+	TIMER0B,      /* 5 - port D5 */
+	TIMER0A,      /* 6 - port D6 */
 #endif
-	NOT_ON_TIMER,
-	NOT_ON_TIMER, /* 8 - port B */
-	TIMER1A,
-	TIMER1B,
+	NOT_ON_TIMER, /* 7 - port D7 */
+	NOT_ON_TIMER, /* 8 - port B0 */ 
+	TIMER1A,      /* 9 - port B1 */
+	TIMER1B,      /* 10- port B2 */
 #if defined(__AVR_ATmega8__)
-	TIMER2,
+	TIMER2,       /* 11- port B3 */
 #else
-	TIMER2A,
+	TIMER2A,      /* 11- port B3 */
 #endif
-	NOT_ON_TIMER,
-	NOT_ON_TIMER,
-	NOT_ON_TIMER,
-	NOT_ON_TIMER, /* 14 - port C */
-	NOT_ON_TIMER,
-	NOT_ON_TIMER,
-	NOT_ON_TIMER,
-	NOT_ON_TIMER,
-	NOT_ON_TIMER,
-	NOT_ON_TIMER,
+	NOT_ON_TIMER, /* 12- port B4 */
+	NOT_ON_TIMER, /* 13- port B5 */
+	NOT_ON_TIMER, /* 14- port C0 */
+	NOT_ON_TIMER, /* 15- port C1 */
+	NOT_ON_TIMER, /* 16- port C2 */
+	NOT_ON_TIMER, /* 17- port C3 */
+	NOT_ON_TIMER, /* 18- port C4 */
+	NOT_ON_TIMER, /* 19- port C5 */
+	NOT_ON_TIMER, /* 20- port E1 */
+	NOT_ON_TIMER, /* 21- port E3 */
 #if defined(__LGT8FX8E__)
-	LGTDAO1,
+	LGTDAO1,      /* 22- port E0 */
 #endif
+#if defined(__LGT8FX8P48__)
+	NOT_ON_TIMER, /* 22- port B6 */
+	NOT_ON_TIMER, /* 23- port C7 */
+	NOT_ON_TIMER, /* 24- port F0 */
+	NOT_ON_TIMER, /* 25- port E6 */
+	NOT_ON_TIMER, /* 26- port E7 */
+	NOT_ON_TIMER, /* 27- port B7 */
+	NOT_ON_TIMER, /* 28- port C6 */
+	NOT_ON_TIMER, /* 29- port E0 */
+	NOT_ON_TIMER, /* 30- port E2 */
+	NOT_ON_TIMER, /* 31- port E4 */
+	NOT_ON_TIMER, /* 32- port E5 */
+	TIMER3A,      /* 33- port F1 */
+	TIMER3B,      /* 34- port F2 */
+	TIMER3C,      /* 35- port F3 */
+	NOT_ON_TIMER, /* 36- port F4 */
+	NOT_ON_TIMER, /* 37- port F5 */
+	NOT_ON_TIMER, /* 38- port F6 */
+	NOT_ON_TIMER, /* 39- port F7 */
+#endif
+
 };
 
 #endif

--- a/lgt8f/variants/standard/pins_arduino.h
+++ b/lgt8f/variants/standard/pins_arduino.h
@@ -407,8 +407,13 @@ const uint8_t PROGMEM port_to_PCMSK_PGM[] = { 0, 0, 0xFF & (uint16_t)&PCMSK0, 0x
 
 const uint8_t PROGMEM digital_pin_to_timer_PGM[] = {
 	NOT_ON_TIMER, /* 0 - port D */
+#if defined(__LGT8FX8E__) || defined(__LGT8FX8P__)
+	TIMER3A,
+	TIMER3B,
+#else
 	NOT_ON_TIMER,
 	NOT_ON_TIMER,
+#endif
 	// on the ATmega168, digital pin 3 has hardware pwm
 #if defined(__AVR_ATmega8__)
 	NOT_ON_TIMER,


### PR DESCRIPTION
LGT8 can do PWM on D1 (via TIMER3A and F1)  and D2 (via TIMER3B and F2).
This was so completely missed out.
There's a little bit of workarounds to take as data direction OUT has to be either for PORTD or PORTF, not both.

Related to #333 