### PR TITLE
resurrect EEPROM.size

### DIFF
--- a/lgt8f/libraries/E2PROM/EEPROM.h
+++ b/lgt8f/libraries/E2PROM/EEPROM.h
@@ -408,6 +408,8 @@ struct EEPROMClass
 		return t;
 	}
 
+	int size() { return lgt_eeprom_size(false); }
+
 	uint16_t change_size( uint8_t number_of_1KB_pages ) 
 	{ 
 		lgt_eeprom_size( number_of_1KB_pages ); 


### PR DESCRIPTION
I tried to build K3NG CW Keyer (https://github.com/k3ng/k3ng_cw_keyer) with lgt8fx-2.0.7 and compiler says "struct EEPROMClass has no member named 'size'".

commit https://github.com/dbuezas/lgt8fx/commit/da14ac9701dfee494c2fc9a65a1573cab1333676 deletes size() so this is need to be re-implemented.
